### PR TITLE
clk: Readd sram clk

### DIFF
--- a/ahb_bus/ahb_bus.xml
+++ b/ahb_bus/ahb_bus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<efx:project name="ahb_bus" description="" last_change_date="Thu December 28 2023 17:37:21" location="/home/chaya/efinity/2023.1/project/ahb_bus" sw_version="2023.1.150" last_run_state="pass" last_run_tool="efx_pgm" last_run_flow="bitstream" config_result_in_sync="true" design_ood="sync" place_ood="sync" route_ood="sync" xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
+<efx:project name="ahb_bus" description="" last_change_date="Fri December 29 2023 16:55:05" location="/home/chaya/efinity/2023.1/project/ahb_bus" sw_version="2023.1.150" last_run_state="crash" last_run_tool="python3" last_run_flow="place" config_result_in_sync="true" design_ood="sync" place_ood="change" route_ood="change" xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
     <efx:device_info>
         <efx:family name="Trion"/>
         <efx:device name="T120F324"/>
@@ -58,9 +58,9 @@
         <efx:param name="work_dir" value="work_pnr" value_type="e_string"/>
         <efx:param name="verbose" value="off" value_type="e_bool"/>
         <efx:param name="load_delaym" value="on" value_type="e_bool"/>
-        <efx:param name="optimization_level" value="NULL" value_type="e_option"/>
+        <efx:param name="optimization_level" value="TIMING_3" value_type="e_option"/>
         <efx:param name="seed" value="1" value_type="e_integer"/>
-        <efx:param name="placer_effort_level" value="2" value_type="e_option"/>
+        <efx:param name="placer_effort_level" value="4" value_type="e_option"/>
         <efx:param name="max_threads" value="-1" value_type="e_integer"/>
     </efx:place_and_route>
     <efx:bitstream_generation tool_name="efx_pgm">

--- a/ahb_bus/constraint.sdc
+++ b/ahb_bus/constraint.sdc
@@ -1,1 +1,2 @@
-create_clock -name hclk -period 10.5000 [get_ports hclk]
+create_clock -name hclk -period 15.000 [get_ports hclk]
+create_clock -name sram_clk -period 15.000 [get_ports sram_clk]

--- a/ahb_bus/rtl/RA1SH_v1.v
+++ b/ahb_bus/rtl/RA1SH_v1.v
@@ -32,7 +32,7 @@ module RA1SH_v1 (
     
    assign Q = q_reg;
 
-        always @(posedge CLK) begin
+        always @(negedge CLK) begin
             if (!CEN) begin
                 if (!WEN) begin
                     mem [A] <= D;

--- a/ahb_bus/rtl/top_wrapper_multi_slaves.v
+++ b/ahb_bus/rtl/top_wrapper_multi_slaves.v
@@ -9,7 +9,7 @@ module top_ahb_multi_slaves #(
     parameter                   TRANS_SIZE = 32  
 )(
     input                       hclk,
-//    input                       sram_clk,
+    input                       sram_clk,
     input                       hresetn,
     input                       stop_trans,
     input                       start_trans,
@@ -104,7 +104,7 @@ interconnect_mux mux (
 
 sramc_top slave1 (
     .hclk            (hclk     ),
-    .sram_clk        (hclk ),
+    .sram_clk        (sram_clk ),
     .hresetn         (hresetn  ),
     .hsel            (w_hsel[0]),
     .hwrite          (w_hwrite ),
@@ -125,7 +125,7 @@ sramc_top slave1 (
 
  sramc_top slave2 (
     .hclk            (hclk     ),
-    .sram_clk        (hclk ),
+    .sram_clk        (sram_clk ),
     .hresetn         (hresetn  ),
     .hsel            (w_hsel[1]),
     .hwrite          (w_hwrite ),
@@ -146,7 +146,7 @@ sramc_top slave1 (
 
  sramc_top slave3 (
     .hclk            (hclk     ),
-    .sram_clk        (hclk ),
+    .sram_clk        (sram_clk ),
     .hresetn         (hresetn  ),
     .hsel            (w_hsel[2]),
     .hwrite          (w_hwrite ),

--- a/ahb_bus/tb/tb_top_ahb_multi_slaves.v
+++ b/ahb_bus/tb/tb_top_ahb_multi_slaves.v
@@ -29,7 +29,7 @@ module tb_top_ahb_multi_slave ();
 
     top_ahb_multi_slaves top_mod(
         .hclk          (hclk),
-//        .sram_clk      (sram_clk),
+        .sram_clk      (sram_clk),
         .hresetn       (hresetn),
         .stop_trans    (stop_trans),
         .start_trans   (start_trans),
@@ -43,7 +43,7 @@ module tb_top_ahb_multi_slave ();
 
     );
     always #5 hclk = ~hclk;
-//    assign sram_clk = ~hclk;
+    assign sram_clk = ~hclk;
     initial begin
 	    hclk = 0;
         start_trans = 0;


### PR DESCRIPTION
Sram clk was removed in the previous commit but the frequency came out to be very less. So it was readded and the design was made to run on sram_clk as well as hclk unlike previously just on hclk.